### PR TITLE
Add buttons for teeshirt size question

### DIFF
--- a/account_profile/scripts.json
+++ b/account_profile/scripts.json
@@ -96,7 +96,41 @@
                                 }
                             ],
                             "multiple": false
-                        }
+                        },
+                        "attachments": [
+                            {
+                                "title": "",
+                                "text": "",
+                                "fields": [],
+                                "actions": [
+                                    {
+                                        "text": "Small",
+                                        "name": "say",
+                                        "value": "small",
+                                        "type": "button"
+                                    },
+                                    {
+                                        "text": "Medium",
+                                        "name": "say",
+                                        "value": "medium",
+                                        "type": "button"
+                                    },
+                                    {
+                                        "text": "Large",
+                                        "name": "say",
+                                        "value": "large",
+                                        "type": "button"
+                                    },
+                                    {
+                                        "text": "XL",
+                                        "name": "say",
+                                        "value": "extra large",
+                                        "type": "button"
+                                    }
+                                ],
+                                "callback_id": "abcd"
+                            }
+                        ]
                     },
                     {
                         "text": [


### PR DESCRIPTION
This file is being referenced from one of the Botkit Studio [tutorials](https://blog.howdy.ai/build-a-bot-store-data-for-your-users-2e91fe7023d7) which talks about the buttons attached to one of the questions. This commit adds those buttons to the JSON file. 